### PR TITLE
Update pairwise.yaml to match public pretrained checkpoint

### DIFF
--- a/configs/pairwise.yaml
+++ b/configs/pairwise.yaml
@@ -6,7 +6,7 @@ epochs: 30            # Total training epochs
 #optimizer: "ranger"       # Optimization algorithm
 dropout: 0.05     # Dropout regularization rate
 weight_decay: 0.0001
-k: 9
+k: 5
 ninp: 256
 nlayers: 9
 nclass: 2


### PR DESCRIPTION
It seems that the publicly available pretrained RibonanzaNet checkpoint does not match the config provided in the Github repo: https://www.kaggle.com/code/shujun717/ribonanzanet-inference/notebook

The k parameter is set to 9 here, whereas the model weights use k = 5.

I've updated k to 5 in the config file here and everything seems to work for me now. 

I'd also suggest updating the public Kaggle notebook, in case what I did is correct.